### PR TITLE
add GKE node service account for artifact registry and ops suite

### DIFF
--- a/terraform/gke.tf
+++ b/terraform/gke.tf
@@ -51,6 +51,7 @@ resource "google_container_node_pool" "gpu_nodes" {
     }
 
     # Important for GPU workload support
+    service_account = google_service_account.gke_node_sa.email
     oauth_scopes = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,23 @@
+# Service Account creation
+resource "google_service_account" "gke_node_sa" {
+  account_id   = "gke-node-sa"
+  display_name = "Service Account for GKE Nodes"
+}
+
+# Grant IAM roles to the service account
+resource "google_project_iam_member" "node_sa_roles" {
+  project = var.project_id
+
+  # List of roles to be assigned 
+  for_each = toset([
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+    "roles/autoscaling.metricsWriter",
+    "roles/artifactregistry.reader"
+  ])
+
+  role   = each.key
+  member = "serviceAccount:${google_service_account.gke_node_sa.email}"
+}


### PR DESCRIPTION
- Add customer IAM Service Account to GKE nodes
- Added roles to the Service Account to be able to pull container images from Artifact Registry and write logs and metrics to Cloud Ops