### PR TITLE
normalise gpu node pool name

### DIFF
--- a/introduction.ipynb
+++ b/introduction.ipynb
@@ -217,7 +217,7 @@
       },
       "outputs": [],
       "source": [
-        "! gcloud container node-pools create t4-pool \\\n",
+        "! gcloud container node-pools create gpu-pool \\\n",
         "  --accelerator type=nvidia-tesla-t4,count=1,gpu-driver-version=default \\\n",
         "  --machine-type=n1-standard-2 \\\n",
         "  --num-nodes=2 \\\n",


### PR DESCRIPTION
Updated the introductory lab to reference the node pool that's created via gcloud will be called gpu-pool, this is inline with the node pool that's created by Terraform in the intermediate lab