### PR TITLE
GKE Workload Identity setup for introduction lab

### DIFF
--- a/introduction.ipynb
+++ b/introduction.ipynb
@@ -648,6 +648,7 @@
         "  template:\n",
         "    metadata:\n",
         "    spec:\n",
+        "      serviceAccountName: sa-ml-training\n",
         "      terminationGracePeriodSeconds: 60\n",
         "      containers:\n",
         "      - name: mnist-train\n",

--- a/introduction.ipynb
+++ b/introduction.ipynb
@@ -531,6 +531,41 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Service Accounts\n",
+        "\n",
+        "In order to let GKE applications authenticate to Google Cloud APIs using Workload Identity Federation for GKE (in this lab we will use GCS APIs to upload our model), you create IAM policies for the specific APIs. We will link Kubernetes SA to IAM - [Reference Link](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam)\n",
+        "\n",
+        "1. Create an IAM service account (sa-gcs-object-creator)\n",
+        "2. Grant the IAM Service account the roles that it needs on specific Google Cloud APIs (GCS Object Creator - - roles/storage.objectCreator)\n",
+        "\n",
+        "Then we will create a Kubernetes Service Account, annotate it so that GKE sees the link between the service accounts. And create an IAM policy that gives the Kubernetes SA access to impersonate the IAM service account."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "! gcloud iam service-accounts create sa-gcs-object-creator \\\n",
+        "--project=$PROJECT_ID"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "! gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
+        "--member \"serviceAccount:sa-gcs-object-creator@{PROJECT_ID}.iam.gserviceaccount.com\" \\\n",
+        "--role \"roles/storage.objectCreator\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "tVL0E7cR6Xam"
       },
@@ -568,7 +603,31 @@
         "id": "pipXnfYmwXRy"
       },
       "source": [
-        "We create a yaml file to create our job with the image that we created in the artifact repositoy"
+        "We create two yaml files:\n",
+        "1. to create a Kubernetes ServiceAccount (sa-ml-training) with annotation to IAM Service Account\n",
+        "2. to create our job with the image that we created in the artifact repositoy"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "sa_yaml_content = f\"\"\"\n",
+        "apiVersion: v1\n",
+        "kind: ServiceAccount\n",
+        "metadata:\n",
+        "  annotations:\n",
+        "    iam.gke.io/gcp-service-account: sa-gcs-object-creator@{PROJECT_ID}.iam.gserviceaccount.com\n",
+        "  name: sa-ml-training\n",
+        "  namespace: default\n",
+        "\"\"\"\n",
+        "\n",
+        "print(sa_yaml_content)\n",
+        "\n",
+        "with open('sa_create.yaml', 'w') as f:\n",
+        "     f.write(sa_yaml_content)"
       ]
     },
     {
@@ -679,11 +738,61 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now we have established connection to our cluster, first we will create our Kubernetes Service account with \"apply\" command"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!kubectl apply -f sa_create.yaml"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Check your service account"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!kubectl get serviceaccounts"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Now create an IAM policy that gives the Kubernetes ServiceAccount (sa-ml-training) access to impersonate the IAM service account (sa-gcs-object-creator)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "! gcloud iam service-accounts add-iam-policy-binding sa-gcs-object-creator@$PROJECT_ID.iam.gserviceaccount.com \\\n",
+        "    --role roles/iam.workloadIdentityUser \\\n",
+        "    --member \"serviceAccount:${PROJECT_ID}.svc.id.goog[default/sa-ml-training]\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "lejHzJqX33hu"
       },
       "source": [
-        "Run, or 'apply' the training job"
+        "Finally we can run our job, or 'apply' the training job"
       ]
     },
     {
@@ -755,6 +864,22 @@
       "outputs": [],
       "source": [
         "!kubectl describe job train-job-1"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You can check the logs of the job:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!kubectl logs job/train-job-1 -f"
       ]
     },
     {

--- a/introduction.ipynb
+++ b/introduction.ipynb
@@ -538,7 +538,7 @@
         "In order to let GKE applications authenticate to Google Cloud APIs using Workload Identity Federation for GKE (in this lab we will use GCS APIs to upload our model), you create IAM policies for the specific APIs. We will link Kubernetes SA to IAM - [Reference Link](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#kubernetes-sa-to-iam)\n",
         "\n",
         "1. Create an IAM service account (sa-gcs-object-creator)\n",
-        "2. Grant the IAM Service account the roles that it needs on specific Google Cloud APIs (GCS Object Creator - - roles/storage.objectCreator)\n",
+        "2. Grant the IAM Service account the roles that it needs on specific Google Cloud APIs (GCS Object User - [roles/storage.objectUser](https://cloud.google.com/storage/docs/access-control/iam-roles))\n",
         "\n",
         "Then we will create a Kubernetes Service Account, annotate it so that GKE sees the link between the service accounts. And create an IAM policy that gives the Kubernetes SA access to impersonate the IAM service account."
       ]
@@ -561,7 +561,7 @@
       "source": [
         "! gcloud projects add-iam-policy-binding $PROJECT_ID \\\n",
         "--member \"serviceAccount:sa-gcs-object-creator@{PROJECT_ID}.iam.gserviceaccount.com\" \\\n",
-        "--role \"roles/storage.objectCreator\""
+        "--role \"roles/storage.objectUser\""
       ]
     },
     {


### PR DESCRIPTION
* Create an IAM SA with GCS Object User (both create and delete access)
* Create a Kubernetes SA
* Link these two that gives the Kubernetes SA access to impersonate the IAM SA.
* Update the job yaml definition with the Kubernetes SA