### PR TITLE
In order to see logs, we need to add roles to the default GCE SA like terraform

### DIFF
--- a/introduction.ipynb
+++ b/introduction.ipynb
@@ -115,7 +115,8 @@
         "os.environ[\"ZONE\"] = \"us-central1-a\"\n",
         "os.environ[\"BUCKET_NAME\"] = \"<your-bucket-name>\"\n",
         "os.environ[\"VPC_NAME\"] = \"default\"\n",
-        "os.environ[\"VPC_SUBNET\"] = \"default\""
+        "os.environ[\"VPC_SUBNET\"] = \"default\"\n",
+        "os.environ[\"GCE_SA_EMAIL\"] = \"<your GCE SA email>\""
       ]
     },
     {
@@ -163,6 +164,20 @@
         "! gcloud services enable iam.googleapis.com\n",
         "! gcloud services enable container.googleapis.com\n",
         "! gcloud services enable cloudbuild.googleapis.com"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Add necessary roles to the default GCE Service Account to be able to write logs, view metrics etc.\n",
+        "! gcloud projects add-iam-policy-binding ${PROJECT_ID} --member=serviceAccount:${GCE_SA_EMAIL} --role=\"roles/logging.logWriter\"\n",
+        "! gcloud projects add-iam-policy-binding ${PROJECT_ID} --member=serviceAccount:${GCE_SA_EMAIL} --role=\"roles/monitoring.metricWriter\"\n",
+        "! gcloud projects add-iam-policy-binding ${PROJECT_ID} --member=serviceAccount:${GCE_SA_EMAIL} --role=\"roles/monitoring.viewer\"\n",
+        "! gcloud projects add-iam-policy-binding ${PROJECT_ID} --member=serviceAccount:${GCE_SA_EMAIL} --role=\"roles/stackdriver.resourceMetadata.writer\"\n",
+        "! gcloud projects add-iam-policy-binding ${PROJECT_ID} --member=serviceAccount:${GCE_SA_EMAIL} --role=\"roles/autoscaling.metricsWriter\""
       ]
     },
     {
@@ -513,7 +528,7 @@
       "source": [
         "! gcloud artifacts repositories add-iam-policy-binding pytorch-t4 \\\n",
         "    --location=us-central1 \\\n",
-        "    --member=serviceAccount:<SERVICE_ACCOUNT_EMAIL> \\\n",
+        "    --member=serviceAccount:${GCE_SA_EMAIL} \\\n",
         "    --role=\"roles/artifactregistry.reader\""
       ]
     },


### PR DESCRIPTION
The default GCE SA didn't have the following roles: 
logging.logWriter, roles/monitoring.metricWriter, roles/monitoring.viewer, roles/stackdriver.resourceMetadata.writer, roles/autoscaling.metricsWriter.

After including these roles, the print logs were written in the Cloud Logging.
So a new environmental variable is created to be able to get the default GCE SA email address and the necessary gcloud commands to add the permissions.